### PR TITLE
Touched Up GET requests and prepared PORT for Heroku deployment

### DIFF
--- a/db/db.json
+++ b/db/db.json
@@ -1,10 +1,5 @@
 [
     {
-        "title": "Test Note 1",
-        "text": "Test text",
-        "id": "aaaa"
-    },
-    {
         "title": "Test Post",
         "text": "This is a test",
         "id": "38a4"

--- a/db/db.json
+++ b/db/db.json
@@ -1,8 +1,8 @@
 [
     {
-        "title": "Test Post",
-        "text": "This is a test",
-        "id": "38a4"
+        "title": "Test Note",
+        "text": "test test test",
+        "id": "aaaa"
     },
     {
         "title": "Pick up milk",

--- a/db/db.json
+++ b/db/db.json
@@ -8,5 +8,20 @@
         "title": "Test Post",
         "text": "This is a test",
         "id": "38a4"
+    },
+    {
+        "title": "Pick up milk",
+        "text": "Don't forget",
+        "id": "e3c7"
+    },
+    {
+        "title": "Shovel the stoop",
+        "text": "Will need a big shovel",
+        "id": "f9e3"
+    },
+    {
+        "title": "Clean the dishes",
+        "text": "Make sure to do it before class today",
+        "id": "5ad6"
     }
 ]

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const db = require('./db/db.json');
 const uuid = require('./helpers/uuid.js');
 //Import fs read/write function from helper js file
 
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 
 const app = express();
 

--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ app.get('/notes/:id', (req, res) => {
 })
 // Notes API
 app.get('/api/notes', (req, res) => {
-    // Redeclares db to update notes.
+    // Reads DB then sends the parsed response, more responsive then just sending a declared variable.
     fs.readFile('./db/db.json', 'utf-8', (err, data) => {
         if (err) {
             console.log(err);

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const NoteWriter = require('./helpers/note-writer.js');
-const db = require('./db/db.json');
+// const db = require('./db/db.json');
 const uuid = require('./helpers/uuid.js');
 //Import fs read/write function from helper js file
 
@@ -39,7 +39,11 @@ app.get('/notes/:id', (req, res) => {
     }
 })
 // Notes API
-app.get('/api/notes', (req, res) => res.json(db));
+app.get('/api/notes', (req, res) => {
+    // Redeclares db to update notes.
+    const db = require('./db/db.json');
+    res.json(db)
+});
 // Takes notes post request and makes a newNote object
 app.post('/api/notes', (req, res) => {
     console.log(`${req.method} request recieved.`)

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const NoteWriter = require('./helpers/note-writer.js');
-// const db = require('./db/db.json');
+const db = require('./db/db.json');
 const uuid = require('./helpers/uuid.js');
 //Import fs read/write function from helper js file
 
@@ -41,8 +41,15 @@ app.get('/notes/:id', (req, res) => {
 // Notes API
 app.get('/api/notes', (req, res) => {
     // Redeclares db to update notes.
-    const db = require('./db/db.json');
-    res.json(db)
+    fs.readFile('./db/db.json', 'utf-8', (err, data) => {
+        if (err) {
+            console.log(err);
+        } else {
+            const updatedDB = JSON.parse(data); 
+            res.json(updatedDB)
+        }
+    });
+    // res.json(updatedDB)
 });
 // Takes notes post request and makes a newNote object
 app.post('/api/notes', (req, res) => {


### PR DESCRIPTION
Instead of just sending DB declared as a required file in the get request, GET /api/notes now reads the DB file and sends a parsed object. Responds better to updates.